### PR TITLE
Truchet on refactor

### DIFF
--- a/geometry.js
+++ b/geometry.js
@@ -94,3 +94,66 @@ const hat_outline = [
     hexPt(2,-1), hexPt(4,-2), hexPt(5,-1), hexPt(4, 0),
     hexPt(3, 0), hexPt(2, 2), hexPt(0, 3), hexPt(0, 2),
     hexPt(-1, 2) ];
+
+function arcPoints(cx,cy,sx,sy,ex,ey,t)
+{
+    function pointToRadian(cx,cy,px,py)
+    {
+	return Math.atan2(py - cy, px - cx);
+    }
+
+    function radianToPoint(cx,cy,rad,radius)
+    {
+	return pt(radius*cos(rad)+cx,radius*sin(rad)+cy);
+    }
+
+    let radius = dist(cx,cy,sx,sy);
+    let points = []
+    for (let i = 0; i <= t; i++)
+    {
+	px = lerp(sx,ex,i/t);
+	py = lerp(sy,ey,i/t);
+	points.push(radianToPoint(cx,cy,pointToRadian(cx,cy,px,py),radius));	
+    }
+    return points;    
+}
+    
+function truchetTopFromHat( shape )
+{
+    // Belt
+    let startpoint = pt(lerp(shape[0].x,shape[1].x,0.5),lerp(shape[0].y,shape[1].y,0.5));
+    let beltShape =  [startpoint,shape[1],shape[2],shape[3],shape[4]];
+    //Upper arc
+    c = shape[5]
+    l = pt(lerp(shape[5].x,shape[4].x,0.5),lerp(shape[5].y,shape[4].y,0.5));
+    r = pt(lerp(shape[5].x,shape[6].x,0.5),lerp(shape[5].y,shape[6].y,0.5));
+    beltShape = beltShape.concat(arcPoints(c.x,c.y,l.x,l.y,r.x,r.y,20));
+    // Right side
+    beltShape = beltShape.concat([shape[6],shape[7],shape[8]]);
+    //lower main arc
+    l = pt(lerp(shape[4].x,shape[0].x,0.5),lerp(shape[4].y,shape[0].y,0.5));		      
+    r = pt(lerp(shape[8].x,shape[9].x,0.5),lerp(shape[8].y,shape[9].y,0.5));
+    beltShape = beltShape.concat(arcPoints(c.x,c.y,r.x,r.y,l.x,l.y,20));
+    //lower minor arc
+    c = shape[0];
+    r = l;
+    l = startpoint;
+    beltShape = beltShape.concat(arcPoints(c.x,c.y,r.x,r.y,l.x,l.y,20));
+    return beltShape
+}
+
+function truchetBtmFromHat( shape )
+{
+    //Bottom disk
+    //The center of the bottom disk
+    let c = hexPt(-2,4);
+    //Left arm
+    let l = pt(lerp(shape[12].x,shape[0].x,0.5),lerp(shape[12].y,shape[0].y,0.5));		      
+    //Right arm
+    let r = pt(lerp(shape[9].x,shape[10].x,0.5),lerp(shape[9].y,shape[10].y,0.5));
+    return [r,shape[10],shape[11],shape[12],l].concat(arcPoints(c.x,c.y,l.x,l.y,r.x,r.y,20));
+}
+
+// It's not safe to defined these yet. This must be done from p5js 'Setup'
+let truchetTop = null;
+let truchetBtm = null;

--- a/hat.js
+++ b/hat.js
@@ -12,7 +12,7 @@ let subst_button;
 let translate_button;
 let scale_button;
 let truchetCheckbox;
-let strokeCheckbox
+let strokeCheckbox;
 let draw_hats;
 let draw_super;
 let radio;
@@ -542,18 +542,18 @@ function setup() {
 
 	let count = 0;
 	for( let [name, col] of Object.entries( cp_info ) ) {
-	    const label = createSpan( name );
-	    label.position( 10 + 70*count, box_height );
-            const cp = createColorPicker( color( ...col ) );
-            cp.mousePressed( function() { loop() } );
-	    cp.position( 10 + 70*count, box_height + 20 );
-	    cols[name] = cp;
-	    
-	    ++count;
-	    if( count == 2 ) {
+		const label = createSpan( name );
+		label.position( 10 + 70*count, box_height );
+		const cp = createColorPicker( color( ...col ) );
+		cp.mousePressed( function() { loop() } );
+		cp.position( 10 + 70*count, box_height + 20 );
+		cols[name] = cp;
+		
+		++count;
+		if( count == 2 ) {
 		count = 0;
 		box_height += 50;
-	    }
+		}
 	}
 	if( count == 1 ) {
 		box_height += 50;
@@ -644,14 +644,14 @@ function setup() {
 
 function draw()
 {
-        background( cols["Plane"].color() );
+	background( cols["Plane"].color() );
 
 	push();
 	translate( width/2, height/2 );
 	const idx = {'H':0, 'T':1, 'P':2, 'F':3}[radio.value()];
 
 	if( isButtonActive( draw_hats ) ) {
-	    tiles[idx].draw( to_screen, level, truchetCheckbox.checked(), strokeCheckbox.checked() );
+		tiles[idx].draw( to_screen, level, truchetCheckbox.checked(), strokeCheckbox.checked() );
 	}
 
 	if( isButtonActive( draw_super ) ) {

--- a/hat.js
+++ b/hat.js
@@ -104,12 +104,12 @@ class HatTile
 
 	drawPolygon(
 	    // The half stroke avoids conflicts when rending truchet patterns atop non-stroked hats
-	    hat_outline, S, cols[this.label].color(), stroke? black: cols[this.label].color(), stroke? 1 : 0.5 );
+	    hat_outline, S, cols[this.label].color(), stroke? cols["Stroke"].color() : cols[this.label].color(), stroke? 1 : 0.5 );
 	if(truchet){
 		drawPolygon( 
-		    truchetTop, S, cols["Truchet"].color(), stroke? black : cols["Truchet"].color(), 1 );
+		    truchetTop, S, cols["Truchet"].color(), stroke? cols["Stroke"].color() : cols["Truchet"].color(), 1 );
 		drawPolygon( 
-		    truchetBtm, S, cols["Truchet"].color(), stroke? black : cols["Truchet"].color(), 1 );
+		    truchetBtm, S, cols["Truchet"].color(), stroke? cols["Stroke"].color() : cols["Truchet"].color(), 1 );
             }
 	}
 
@@ -129,12 +129,12 @@ class HatTile
 		this.svg_id = getSVGID();
 		// The half stroke avoids conflicts when rending truchet patterns atop non-stroked hats
 		const strokeWidth = stroke ? lw_scale / sc : 0.5 * lw_scale / sc;
-		const strokeColor = stroke ? black : cols[this.label].color();
+		const strokeColor = stroke ? cols["Stroke"].color() : cols[this.label].color();
 		stream.push(polygonToSVG(hat_outline, this.svg_id,
 			     cols[this.label].color(), strokeColor, strokeWidth));
 
 		if (truchet) {
-			const truchetStrokeColor = stroke ? black : cols["Truchet"].color();
+			const truchetStrokeColor = stroke ? cols["Stroke"].color() : cols["Truchet"].color();
 			this.svg_id_t1 = getSVGID();
 			this.svg_id_t2 = getSVGID();
 			stream.push(polygonToSVG(truchetTop, this.svg_id_t1,


### PR DESCRIPTION
A follow up to https://github.com/isohedral/hatviz/pull/8 this time based on the refactored version of the original.

- Truchet pattern also on SVG outputs.
- Control plane, Truchet and stroke colors.
- Checkboxes to toggle Truchet pattern and strokes.

I'm hosting a copy of this version here: 
https://www.johansivertsen.com/customhatviz/app.html