### PR TITLE
Use uB to calculate line segment intersection

### DIFF
--- a/geometry.js
+++ b/geometry.js
@@ -86,7 +86,7 @@ function intersect( p1, q1, p2, q2 )
     const uA = ((q2.x - p2.x) * (p1.y - p2.y) - (q2.y - p2.y) * (p1.x - p2.x)) / d;
     const uB = ((q1.x - p1.x) * (p1.y - p2.y) - (q1.y - p1.y) * (p1.x - p2.x)) / d;
 
-    return pt( p1.x + uA * (q1.x - p1.x), p1.y + uA * (q1.y - p1.y) );
+    return pt( p1.x + uA * (q1.x - p1.x), p1.y + uB * (q1.y - p1.y) );
 }
 
 const hat_outline = [


### PR DESCRIPTION
I came across this extremely helpful repo when trying to put the "hat" in a cartesian coordinate system.
I noticed, that `uB` is not used in function `intersect`.
I wasn't able to figure out if not using `uB` was intentional (in wich case this line could be removed), or
if it should be used for calculating the return value.
https://github.com/isohedral/hatviz/blob/a2a068bf8f3c184ce2210597a72cece8e0d74de8/geometry.js#L85-L89

https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line_segment